### PR TITLE
Update status for m2crypto

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,10 +117,7 @@ For the Py3 movement, some sub-requirements has to be ported also.
 
 * m2crypto
 
-  - status:   ``origin/six`` passed 95% of Py27 & Py35 tests
-  - origin:   https://github.com/return42/m2crypto  six
-  - upstream: https://gitlab.com/m2crypto/m2crypto  python3
+  - status: Version 0.28.0 or newer support Python 2.7 and 3.3-3.6
 
-  M2Crypto is needed by PyBrowserID.  The ``origin:six`` branch of M2crypto is
-  just a hack for the period of transition. In the long term, we should replace
+  M2Crypto is needed by PyBrowserID. In the long term, we should replace
   M2crypto with https://cryptography.io


### PR DESCRIPTION
Noticed that m2crypto is still listed as requiring porting but an release from February 2018 fixes this in upstream.

PS: Stumbled upon this repository by your comment at https://github.com/mozilla-services/syncserver/issues/97. Are you still interested in working on this / receiving PRs?